### PR TITLE
sway: use default config if focused window provides no app_id or window_properties

### DIFF
--- a/src/active_client.rs
+++ b/src/active_client.rs
@@ -42,7 +42,9 @@ pub async fn get_active_window(environment: &Environment, config: &Vec<Config>) 
                     {
                         Some(window) => match window.app_id {
                             Some(id) => Client::Class(id),
-                            None => Client::Class(window.window_properties.unwrap().class.unwrap()),
+                            None => window.window_properties
+                                .and_then(|window_properties| window_properties.class)
+                                .map_or(Client::Default, Client::Class),
                         },
                         None => Client::Default,
                     };

--- a/src/event_reader.rs
+++ b/src/event_reader.rs
@@ -566,7 +566,7 @@ impl EventReader {
                 (
                     EventType::ABSOLUTE,
                     _,
-                    AbsoluteAxisType::ABS_RZ | AbsoluteAxisType::ABS_Z,
+                    AbsoluteAxisType::ABS_RX | AbsoluteAxisType::ABS_RY,
                     false,
                 ) => match self.settings.rstick.function.as_str() {
                     "cursor" | "scroll" => {
@@ -574,11 +574,7 @@ impl EventReader {
                             .get_axis_value(&event, &self.settings.rstick.deadzone)
                             .await;
                         let mut rstick_position = self.rstick_position.lock().await;
-                        if event.code() == 2 {
-                          rstick_position[event.code() as usize - 2] = axis_value;
-                        } else {
-                          rstick_position[event.code() as usize - 4] = axis_value;
-                        }
+                        rstick_position[event.code() as usize - 3] = axis_value;
                     }
                     "bind" => {
                         let axis_value = self
@@ -592,7 +588,7 @@ impl EventReader {
                             0
                         };
                         match AbsoluteAxisType(event.code()) {
-                            AbsoluteAxisType::ABS_RZ => match clamped_value {
+                            AbsoluteAxisType::ABS_RY => match clamped_value {
                                 -1 => {
                                     if rstick_values.1 != -1 {
                                         self.convert_event(
@@ -645,7 +641,7 @@ impl EventReader {
                                 }
                                 _ => {}
                             },
-                            AbsoluteAxisType::ABS_Z => match clamped_value {
+                            AbsoluteAxisType::ABS_RX => match clamped_value {
                                 -1 if rstick_values.0 != -1 => {
                                     self.convert_event(
                                         event,

--- a/src/event_reader.rs
+++ b/src/event_reader.rs
@@ -566,7 +566,7 @@ impl EventReader {
                 (
                     EventType::ABSOLUTE,
                     _,
-                    AbsoluteAxisType::ABS_RX | AbsoluteAxisType::ABS_RY,
+                    AbsoluteAxisType::ABS_RZ | AbsoluteAxisType::ABS_Z,
                     false,
                 ) => match self.settings.rstick.function.as_str() {
                     "cursor" | "scroll" => {
@@ -574,7 +574,11 @@ impl EventReader {
                             .get_axis_value(&event, &self.settings.rstick.deadzone)
                             .await;
                         let mut rstick_position = self.rstick_position.lock().await;
-                        rstick_position[event.code() as usize - 3] = axis_value;
+                        if event.code() == 2 {
+                          rstick_position[event.code() as usize - 2] = axis_value;
+                        } else {
+                          rstick_position[event.code() as usize - 4] = axis_value;
+                        }
                     }
                     "bind" => {
                         let axis_value = self
@@ -588,7 +592,7 @@ impl EventReader {
                             0
                         };
                         match AbsoluteAxisType(event.code()) {
-                            AbsoluteAxisType::ABS_RY => match clamped_value {
+                            AbsoluteAxisType::ABS_RZ => match clamped_value {
                                 -1 => {
                                     if rstick_values.1 != -1 {
                                         self.convert_event(
@@ -641,7 +645,7 @@ impl EventReader {
                                 }
                                 _ => {}
                             },
-                            AbsoluteAxisType::ABS_RX => match clamped_value {
+                            AbsoluteAxisType::ABS_Z => match clamped_value {
                                 -1 if rstick_values.0 != -1 => {
                                     self.convert_event(
                                         event,


### PR DESCRIPTION
In using Makima, I found that the program was crashing if the focused 'window' provided neither an `app_id` nor `window_properties` (which provides the window's `class`). As far as I saw, this only occurred when sway's focus was on a window with the type of `workspace` (as opposed to `con` and `floating_con` which are tiled and floating program windows respectively) as sway's workspaces do not appear to provide either values, but are identified as focused windows.
Apologies if there's a better way of going about this, I don't work much with Rust but this change did appear to prevent the crash while preserving configuration identification for wayland (`app_id`) and xwayland (`window_properties>class`) programs.

I could very well be mistaken, but it's my understanding that Makima does not expect to find a focused_window when a `workspace` is focused, and uses the default configuration only when no focused window is found. I'm unsure of a scenario in which Makima would not find a focused window in Sway, however I opted to preserve the existing behavior and make minimal changes in this PR as I could imagine that those scenarios do exist outside of my experience or knowledge.

Original output prior to, and backtrace following panic in Makima v0.9.5:
```
MAKIMA_CONFIG environment variable is not set, defaulting to "/home/pogmommy/.config/makima".

Parsing config file:
"Google LLC Stadia Controller rev. A.toml"

Parsing config file:
"StadiaNYF2-a285.toml"

Parsing config file:
"Sony Computer Entertainment Wireless Controller.toml"

Parsing config file:
"Generic X-Box pad.toml"

Parsing config file:
"Google LLC Stadia Controller rev. A::steam.toml"

Running on sway, per application bindings enabled.
Warning: user has no access to event devices, Makima might not be able to detect all connected devices.
Note: Run Makima with 'sudo -E makima' or as a system service. Refer to the docs for more info. Continuing...

"Sony Computer Entertainment Wireless Controller" detected, reading events.

"Google LLC Stadia Controller rev. A" detected, reading events.

thread 'tokio-runtime-worker' panicked at src/active_client.rs:45:76:
called `Option::unwrap()` on a `None` value
stack backtrace:
   0:     0x562173ea0215 - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::hd736fd5964392270
   1:     0x562173ec8e1b - core::fmt::write::hc6043626647b98ea
   2:     0x562173e9cedf - std::io::Write::write_fmt::h0d24b3e0473045db
   3:     0x562173e9ffee - std::sys_common::backtrace::print::h45eb8174d25a1e76
   4:     0x562173ea1389 - std::panicking::default_hook::{{closure}}::haf3f0170eb4f3b53
   5:     0x562173ea112a - std::panicking::default_hook::hb5d3b27aa9f6dcda
   6:     0x562173ea1823 - std::panicking::rust_panic_with_hook::h6b49d59f86ee588c
   7:     0x562173ea16cb - std::panicking::begin_panic_handler::{{closure}}::hd4c2f7ed79b82b70
   8:     0x562173ea06d9 - std::sys_common::backtrace::__rust_end_short_backtrace::h2946d6d32d7ea1ad
   9:     0x562173ea1437 - rust_begin_unwind
  10:     0x562173d727a3 - core::panicking::panic_fmt::ha02418e5cd774672
  11:     0x562173d7284c - core::panicking::panic::h6c780fb115b2371d
  12:     0x562173d72709 - core::option::unwrap_failed::hff19eb16beb38f1f
  13:     0x562173d983f3 - makima::active_client::get_active_window::{{closure}}::h4661cb56605afd02
  14:     0x562173d9ada7 - makima::event_reader::EventReader::update_config::{{closure}}::h0fab9a421e7a8cdd
  15:     0x562173d80582 - makima::event_reader::EventReader::convert_event::{{closure}}::h85c2a4ec9f6fad5a
  16:     0x562173d7efa7 - makima::event_reader::EventReader::event_loop::{{closure}}::hc47e34e41e7a5266
  17:     0x562173dde26f - <tokio::future::poll_fn::PollFn<F> as core::future::future::Future>::poll::hbcdc16e7f168cedf
  18:     0x562173dca1ae - makima::udev_monitor::start_reader::{{closure}}::hf191dadca0f20e06
  19:     0x562173dc7710 - tokio::runtime::task::core::Core<T,S>::poll::h2018465680fd9abe
  20:     0x562173de2103 - tokio::runtime::task::harness::Harness<T,S>::poll::h6ccfa6d13e1216ce
  21:     0x562173e37dcd - tokio::runtime::scheduler::multi_thread::worker::Context::run_task::h2741b099b48265d7
  22:     0x562173e371a8 - tokio::runtime::scheduler::multi_thread::worker::Context::run::hb87403ed5c3f9dd0
  23:     0x562173e31067 - tokio::runtime::context::runtime::enter_runtime::h1a29470bac2c7e19
  24:     0x562173e36668 - tokio::runtime::scheduler::multi_thread::worker::run::haf0ef77238e6d0d0
  25:     0x562173e331b3 - tokio::runtime::task::core::Core<T,S>::poll::h6d9355c82066be28
  26:     0x562173e432c2 - tokio::runtime::task::harness::Harness<T,S>::poll::hed448fe9b946c0b3
  27:     0x562173e3e728 - tokio::runtime::blocking::pool::Inner::run::h082f22ec66ffab0b
  28:     0x562173e29d1f - std::sys_common::backtrace::__rust_begin_short_backtrace::h6359e52f13b7789a
  29:     0x562173e2a702 - core::ops::function::FnOnce::call_once{{vtable.shim}}::h6e30cdf81a315b47
  30:     0x562173ea66cb - std::sys::pal::unix::thread::Thread::new::thread_start::hb85dbfa54ba503d6
  31:     0x7f7feec5af52 - <unknown>
  32:     0x7f7feecd9678 - <unknown>
  33:                0x0 - <unknown>
```