### PR TITLE
Write current layout to the file for easier integrations

### DIFF
--- a/src/event_reader.rs
+++ b/src/event_reader.rs
@@ -323,7 +323,16 @@ let config_dir = std::env::var("MAKIMA_CONFIG")
         let home = std::env::var("HOME").expect("HOME environment variable not set");
         format!("{}/.config/makima", home)
     });
-let file_path = std::path::PathBuf::from(&config_dir).join("current_layout");
+ let initial_config_name = config
+    .iter()
+    .find(|&x| x.associations == Associations::default())
+    .unwrap()
+    .name
+    .clone();
+
+// Create the file path with config name
+let file_path = std::path::PathBuf::from(&config_dir)
+    .join(format!("{}::current_layout", initial_config_name));
 
 if let Some(parent) = file_path.parent() {
     let _ = std::fs::create_dir_all(parent);
@@ -1371,9 +1380,19 @@ Self {
             let home = std::env::var("HOME").expect("HOME environment variable not set");
             format!("{}/.config/makima", home)
         });
-    let file_path = std::path::PathBuf::from(&config_dir).join("current_layout");
+
+    let config_name = self.config
+            .iter()
+            .find(|&x| x.associations == Associations::default())
+            .unwrap()
+            .name
+            .clone();
+
+    let file_path = std::path::PathBuf::from(&config_dir)
+            .join(format!("{}::current_layout", config_name));
+            
     let _ = std::fs::write(&file_path, format!("{}\n", *active_layout));
-    
+        
     if self.settings.notify_layout_switch {
         let notify = vec![String::from(format!(
             "notify-send -t 500 'Makima' 'Switching to layout {}'",

--- a/src/event_reader.rs
+++ b/src/event_reader.rs
@@ -1395,7 +1395,7 @@ Self {
         
     if self.settings.notify_layout_switch {
         let notify = vec![String::from(format!(
-            "notify-send -t 500 'Makima' 'Switching to layout {}'",
+            "notify-send -e -t 500 'Makima' 'Switching to layout {}'",
             *active_layout
         ))];
         self.spawn_subprocess(&notify).await;


### PR DESCRIPTION
Hey! First I want to say thanks for the project. I really liked it and it enabled me to create the complete macros-layout for my main keyboard with caps-lock button.

I really liked the fact it used the hyprland notify-send integration to indicate layout change, but I went further and made the simple utility button-like indicator that shows 0 or 1 depending on what layout I am. 

So I've edited sources to add the `current_layout` file and modify it on every layout change then read this file contents and update my button.

Wanted to share this in case someone needs it. Feel free to hit me up for further improvements or anything