### PR TITLE
fix: remove BTN_DPAD_* from Axis::from_str() (closes #44)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -37,10 +37,6 @@ impl FromStr for Axis {
     type Err = String;
     fn from_str(s: &str) -> Result<Axis, Self::Err> {
         match s {
-            "BTN_DPAD_UP" => Ok(Axis::BTN_DPAD_UP),
-            "BTN_DPAD_DOWN" => Ok(Axis::BTN_DPAD_DOWN),
-            "BTN_DPAD_LEFT" => Ok(Axis::BTN_DPAD_LEFT),
-            "BTN_DPAD_RIGHT" => Ok(Axis::BTN_DPAD_RIGHT),
             "LSTICK_UP" => Ok(Axis::LSTICK_UP),
             "LSTICK_DOWN" => Ok(Axis::LSTICK_DOWN),
             "LSTICK_LEFT" => Ok(Axis::LSTICK_LEFT),


### PR DESCRIPTION
## Problem

`BTN_DPAD_UP`, `BTN_DPAD_DOWN`, `BTN_DPAD_LEFT`, and `BTN_DPAD_RIGHT` were listed in `Axis::from_str()`, causing them to be classified as axis events instead of key events. Any config entries using `BTN_DPAD_*` were silently ignored — the D-Pad produced no output at all.

## Fix

Removing the four entries from `Axis::from_str()` lets them fall through to `Key::from_str()` where they are correctly handled as button events.

## Tested on

Steam Deck — D-Pad works correctly after this fix.

Closes #44